### PR TITLE
✨ Persist messages on bot restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A very simple [Discord](https://discord.com) bot that integrates with [Google's 
 
 - Chat with the PaLM API while saving the context of the conversation.
 - Simply prefix your prompt with `$ ` to have the bot respond to you in an ongoing chat.
-- The bot begins a brand new context every time the bot is restarted.
+- The bot persists the conversation context in a local `messages.txt` file so it can continue the conversation even if you restart the bot.
 - Generate text, code, and more with the PaLM API!
 
 This Discord bot is built with [discord.py](https://discordpy.readthedocs.io/en/stable/).

--- a/helpers.py
+++ b/helpers.py
@@ -9,8 +9,17 @@ palm.configure(api_key=PALM_API_KEY)
 
 class PalmOutputGenerator:
     def __init__(self):
-        self.response = palm.chat(messages=["Hi"])
+        # Persist messages by using a .txt file.
+        with open("messages.txt", "r") as f:
+            # TODO: Implement better method to store and separate messages
+            messages = f.read().splitlines()
+            if len(messages) == 0:
+                messages = ["Hi"]
+            self.response = palm.chat(messages=messages)
 
     async def generate_palm_output(self, prompt):
         self.response = self.response.reply(prompt)
+        with open("messages.txt", "a") as f:
+            f.write(prompt + "\n")
+            f.write(self.response.last + "\n")
         return self.response.last


### PR DESCRIPTION
✨ Persist messages on bot restart using a local `messages.txt` file.
